### PR TITLE
Fix multi-word wiki searches.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-super-confluence",
   "description": "A hubot script for searching and browsing Confluence.",
-  "version": "0.1.4",
+  "version": "0.2.1",
   "author": "Lucas Chi",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts",

--- a/src/super-confluence.coffee
+++ b/src/super-confluence.coffee
@@ -37,7 +37,7 @@ module.exports = (robot) ->
 
 textSearch = (response) ->
 
-  query = response.match[1]
+  query = encodeURIComponent(response.match[1])
   opts =
     limit: 5
 
@@ -54,7 +54,7 @@ textSearch = (response) ->
 
 autoRespond = (response) ->
 
-  query = response.match[1]
+  query = encodeURIComponent(response.match[1])
   opts =
     limit: 5
 


### PR DESCRIPTION
Solution: do not use URI encoding, confluence does not like it.